### PR TITLE
Implement NotificationsViewModel

### DIFF
--- a/ACHNBrowserUI/ACHNBrowserUI/packages/Backend/Sources/Backend/services/NotificationsService.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/packages/Backend/Sources/Backend/services/NotificationsService.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  NotificationsService .swift
 //  
 //
 //  Created by Rohan Ramakrishnan on 6/14/20.
@@ -10,18 +10,18 @@ import Foundation
 public class NotificationsService {
     public static var shared = NotificationsService()
     
-    public var shopSettingsEnabled: Bool = false {
+    public var shopNotificationsEnabled: Bool = false {
         didSet {
             NotificationManager.shared.removeShopNotifications()
-            if shopSettingsEnabled {
+            if shopNotificationsEnabled {
                 registerShopNotifications()
             }
         }
     }
-    public var eventSettingsEnabled: Bool = false {
+    public var eventNotificationsEnabled: Bool = false {
         didSet {
             NotificationManager.shared.removeShopNotifications()
-            if eventSettingsEnabled {
+            if eventNotificationsEnabled {
                 // TODO function for registering events
             }
         }

--- a/ACHNBrowserUI/ACHNBrowserUI/viewModels/NotificationsViewModel.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/viewModels/NotificationsViewModel.swift
@@ -24,4 +24,6 @@ class NotificationsViewModel: ObservableObject {
             NotificationsService.shared.eventNotificationsEnabled = eventNotificationsEnabled
         }
     }
+    
+    @Published var useDeviceTime = appUserDefaults.isGameTimeInSync
 }

--- a/ACHNBrowserUI/ACHNBrowserUI/viewModels/NotificationsViewModel.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/viewModels/NotificationsViewModel.swift
@@ -9,6 +9,19 @@
 import Foundation
 import Combine
 import Backend
+
 class NotificationsViewModel: ObservableObject {
     
+    private static let appUserDefaults = AppUserDefaults.shared
+    
+    @Published var shopNotificationsEnabled = appUserDefaults.shopNotificationsEnabled {
+        didSet {
+            NotificationsService.shared.shopNotificationsEnabled = shopNotificationsEnabled
+        }
+    }
+    @Published var eventNotificationsEnabled = appUserDefaults.specialEventNotificationsEnabled {
+        didSet {
+            NotificationsService.shared.eventNotificationsEnabled = eventNotificationsEnabled
+        }
+    }
 }

--- a/ACHNBrowserUI/ACHNBrowserUI/views/settings/SettingsView.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/settings/SettingsView.swift
@@ -124,10 +124,8 @@ struct SettingsView: View {
                     }
             }
             
-            HStack {
-                Toggle(isOn: $appUserDefaults.isGameTimeInSync ) {
-                    Text("Use device time for notifications")
-                }
+            Toggle(isOn: $appUserDefaults.isGameTimeInSync ) {
+                Text("Use device time for notifications")
             }
 
         }
@@ -160,28 +158,20 @@ struct SettingsView: View {
     
     private var notificationSection: some View {
         Section(header: SectionHeaderView(text: "Notifications", icon: "clock")) {
-            HStack {
-                Toggle(isOn: $appUserDefaults.shopNotificationsEnabled ) {
-                    Text("When shops open/close")
-                }
+            Toggle(isOn: $appUserDefaults.shopNotificationsEnabled ) {
+                Text("When shops open/close")
             }
             
-            HStack {
-                Toggle(isOn: $appUserDefaults.specialEventNotificationsEnabled) {
-                    Text("Special Events")
-                }
+            Toggle(isOn: $appUserDefaults.specialEventNotificationsEnabled) {
+                Text("Special Events")
             }
             
-            HStack {
-                Toggle(isOn: $appUserDefaults.isTurnipPriceChangesOn) {
-                    Text("Turnip Price Changes")
-                }
+            Toggle(isOn: $appUserDefaults.isTurnipPriceChangesOn) {
+                Text("Turnip Price Changes")
             }
             
-            HStack {
-                Toggle(isOn: $appUserDefaults.isTurnipSellBuyOn) {
-                    Text("Turnip Sell/Buy reminder")
-                }
+            Toggle(isOn: $appUserDefaults.isTurnipSellBuyOn) {
+                Text("Turnip Sell/Buy reminder")
             }
         }
     }

--- a/ACHNBrowserUI/ACHNBrowserUI/views/settings/SettingsView.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/settings/SettingsView.swift
@@ -129,11 +129,6 @@ struct SettingsView: View {
                         Text(LocalizedStringKey(service.rawValue.capitalized)).tag(service)
                     }
             }
-            
-            Toggle(isOn: $appUserDefaults.isGameTimeInSync ) {
-                Text("Use device time for notifications")
-            }
-
         }
     }
     
@@ -165,11 +160,15 @@ struct SettingsView: View {
     private var notificationSection: some View {
         Section(header: SectionHeaderView(text: "Notifications", icon: "clock")) {
             Toggle(isOn: $viewModel.shopNotificationsEnabled) {
-                Text("When shops open/close")
+                Text("Enable shop notifications")
             }
             
             Toggle(isOn: $viewModel.eventNotificationsEnabled) {
-                Text("Special Events")
+                Text("Enable special event notifications")
+            }
+            
+            Toggle(isOn: $viewModel.useDeviceTime) {
+                Text("Use device time for notifications")
             }
         }
     }

--- a/ACHNBrowserUI/ACHNBrowserUI/views/settings/SettingsView.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/settings/SettingsView.swift
@@ -14,6 +14,7 @@ struct SettingsView: View {
     @EnvironmentObject private var collection: UserCollection
     @EnvironmentObject private var subscriptionManager: SubscriptionManager
     @Environment(\.presentationMode) private var presentationMode
+    @ObservedObject private var viewModel: NotificationsViewModel
     @ObservedObject var appUserDefaults = AppUserDefaults.shared
     
     @State private var isDocumentPickerPresented = false
@@ -21,6 +22,11 @@ struct SettingsView: View {
     @State private var importedFile: URL?
     @State private var showSuccessImportAlert = false
     @State private var showDeleteConfirmationAlert = false
+    
+    init(viewModel: NotificationsViewModel) {
+        self.viewModel = viewModel
+    }
+    
     var body: some View {
         NavigationView {
             Form {
@@ -158,20 +164,12 @@ struct SettingsView: View {
     
     private var notificationSection: some View {
         Section(header: SectionHeaderView(text: "Notifications", icon: "clock")) {
-            Toggle(isOn: $appUserDefaults.shopNotificationsEnabled ) {
+            Toggle(isOn: $viewModel.shopNotificationsEnabled) {
                 Text("When shops open/close")
             }
             
-            Toggle(isOn: $appUserDefaults.specialEventNotificationsEnabled) {
+            Toggle(isOn: $viewModel.eventNotificationsEnabled) {
                 Text("Special Events")
-            }
-            
-            Toggle(isOn: $appUserDefaults.isTurnipPriceChangesOn) {
-                Text("Turnip Price Changes")
-            }
-            
-            Toggle(isOn: $appUserDefaults.isTurnipSellBuyOn) {
-                Text("Turnip Sell/Buy reminder")
             }
         }
     }
@@ -234,7 +232,7 @@ struct SettingsView: View {
 
 struct SettingsView_Previews: PreviewProvider {
     static var previews: some View {
-        SettingsView()
+        SettingsView(viewModel: NotificationsViewModel())
             .environmentObject(SubscriptionManager.shared)
             .environmentObject(UserCollection.shared)
     }

--- a/ACHNBrowserUI/ACHNBrowserUI/views/shared/Sheet.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/shared/Sheet.swift
@@ -66,7 +66,8 @@ struct Sheet: View {
         case .about:
             return AnyView(AboutView())
         case .settings(let subManager, let collection):
-            return AnyView(SettingsView()
+            let viewModel = NotificationsViewModel()
+            return AnyView(SettingsView(viewModel: viewModel)
                 .environmentObject(subManager)
                 .environmentObject(collection))
         case .turnipsForm(let subManager):


### PR DESCRIPTION
Creating a draft because I'm adding the actual event logic soon. Some relevant notes:

- I removed the turnip indicator from settings because it exists in the TurnipFormView. Since that page is controlled by the subscription, I think we should leave that as is and leave the responsibility of enabling/disabling notifications to the toggle in that view.
- NotificationViewModel uses appUserDefault variables but publishes them so that we can send messages to the backend to register and remove notifications based on user settings while setting them in UserDefaults